### PR TITLE
Update NSFont in FontsTemplate to use pointSize

### DIFF
--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -73,7 +73,7 @@ extension SynthesizedResourceInterfaceTemplates {
           fatalError("Unable to initialize font '\\(name)' (\\(family))")
         }
         #if os(macOS)
-        return SwiftUI.Font.custom(font.fontName, size: font.size)
+        return SwiftUI.Font.custom(font.fontName, size: font.pointSize)
         #elseif os(iOS) || os(tvOS) || os(watchOS)
         return SwiftUI.Font(font)
         #endif


### PR DESCRIPTION
### Short description 📝

Fixed the error below. I missed the case for NSFont.

<img width="781" alt="image" src="https://user-images.githubusercontent.com/77208067/234990926-53b7a395-c458-4cb8-b144-0591692a10b7.png">

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
